### PR TITLE
Add HTTP Streamable transport and session management for MCP

### DIFF
--- a/eru-ai/module_server/mcp_server.go
+++ b/eru-ai/module_server/mcp_server.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/eru-tech/eru/eru-ai/agents"
 	"github.com/eru-tech/eru/eru-ai/models"
 	"github.com/eru-tech/eru/eru-ai/module_store"
-	tools_factory "github.com/eru-tech/eru/eru-ai/tools/tools_factory"
+	eru_models "github.com/eru-tech/eru/eru-models"
 	logs "github.com/eru-tech/eru/eru-logs/eru-logs"
 	"github.com/eru-tech/eru/eru-server/server"
 )
@@ -17,6 +18,7 @@ const (
 	MCPProtocolVersion = "2025-06-18"
 	ServerName         = "eru-ai-mcp-server"
 	ServerVersion      = "1.0.1"
+	mcpNameSep         = "__"
 )
 
 type EruAIMCPServer struct {
@@ -31,16 +33,6 @@ func NewEruAIMCPServer(store *module_store.StoreHolder) *EruAIMCPServer {
 			Tools: &server.MCPToolsCapability{
 				ListChanged: true,
 			},
-			/* Resources: &server.MCPResourcesCapability{
-				Subscribe:   true,
-				ListChanged: true,
-			},
-			Prompts: &server.MCPPromptsCapability{
-				ListChanged: true,
-			},
-			Logging: &server.MCPLoggingCapability{
-				Level: "info",
-			}, */
 		},
 	}
 }
@@ -60,24 +52,6 @@ func (s *EruAIMCPServer) Initialize(ctx context.Context, params server.MCPInitia
 
 func (s *EruAIMCPServer) ListTools(ctx context.Context) (server.MCPListToolsResult, error) {
 	var mcpTools []server.MCPTool
-
-	// Add global tools using tools factory (same as /tools endpoint)
-	toolName := "MS_EMAIL" // get it from env variable
-	tool := tools_factory.GetTool(toolName)
-	globalTools := tool.GetMcpTools()
-
-	// Convert to MCP format
-	for _, globalTool := range globalTools {
-		mcpTool := server.MCPTool{
-			Name:        globalTool.ToolName,
-			Description: globalTool.ToolDescription,
-			InputSchema: map[string]interface{}{
-				"type":       "object",
-				"properties": make(map[string]interface{}),
-			},
-		}
-		mcpTools = append(mcpTools, mcpTool)
-	}
 
 	projectList := s.store.Store.GetProjectList(ctx)
 
@@ -112,7 +86,7 @@ func (s *EruAIMCPServer) ListTools(ctx context.Context) (server.MCPListToolsResu
 				}
 
 				mcpTool := server.MCPTool{
-					Name:        fmt.Sprintf("%s_%s_%s", projectName, tenant.TenantId, toolName),
+					Name:        strings.Join([]string{projectName, tenant.TenantId, toolName}, mcpNameSep),
 					Description: description,
 					InputSchema: s.convertSchemaToInputSchema(tool.GetParameters()),
 				}
@@ -142,7 +116,7 @@ func (s *EruAIMCPServer) ListTools(ctx context.Context) (server.MCPListToolsResu
 				}
 
 				mcpTool := server.MCPTool{
-					Name:        fmt.Sprintf("%s_%s_agent_%s", projectName, tenant.TenantId, agentName),
+					Name:        strings.Join([]string{projectName, tenant.TenantId, "agent", agentName}, mcpNameSep),
 					Description: description,
 					InputSchema: map[string]interface{}{
 						"type": "object",
@@ -164,6 +138,10 @@ func (s *EruAIMCPServer) ListTools(ctx context.Context) (server.MCPListToolsResu
 		}
 	}
 
+	if mcpTools == nil {
+		mcpTools = []server.MCPTool{}
+	}
+
 	return server.MCPListToolsResult{
 		Tools: mcpTools,
 	}, nil
@@ -172,7 +150,7 @@ func (s *EruAIMCPServer) ListTools(ctx context.Context) (server.MCPListToolsResu
 func (s *EruAIMCPServer) CallTool(ctx context.Context, conversationId string, params server.MCPCallToolParams) (server.MCPCallToolResult, error) {
 	parts := s.parseToolName(params.Name)
 	if len(parts) < 3 {
-		return server.MCPCallToolResult{}, fmt.Errorf("invalid tool name format")
+		return server.MCPCallToolResult{}, fmt.Errorf("invalid tool name format: %s", params.Name)
 	}
 
 	project := parts[0]
@@ -180,9 +158,8 @@ func (s *EruAIMCPServer) CallTool(ctx context.Context, conversationId string, pa
 
 	if len(parts) == 4 && parts[2] == "agent" {
 		return s.executeAgent(ctx, conversationId, project, tenant, parts[3], params.Arguments)
-	} else {
-		return s.executeToolAction(ctx, conversationId, project, tenant, parts[2], params.Arguments)
 	}
+	return s.executeToolAction(ctx, conversationId, project, tenant, parts[2], params.Arguments)
 }
 
 func (s *EruAIMCPServer) executeAgent(ctx context.Context, conversationId, project, tenant, agentName string, arguments map[string]interface{}) (server.MCPCallToolResult, error) {
@@ -295,33 +272,55 @@ func (s *EruAIMCPServer) GetServerInfo() server.MCPServerInfo {
 	}
 }
 
+// parseToolName splits an MCP tool name on the __ separator.
+// Tool names use the format: project__tenant__toolname
+// Agent names use the format: project__tenant__agent__agentname
 func (s *EruAIMCPServer) parseToolName(toolName string) []string {
-	var parts []string
-	current := ""
-
-	for _, char := range toolName {
-		if char == '_' {
-			if current != "" {
-				parts = append(parts, current)
-				current = ""
-			}
-		} else {
-			current += string(char)
-		}
-	}
-
-	if current != "" {
-		parts = append(parts, current)
-	}
-
-	return parts
+	return strings.Split(toolName, mcpNameSep)
 }
 
 func (s *EruAIMCPServer) convertSchemaToInputSchema(schema interface{}) map[string]interface{} {
 	inputSchema := map[string]interface{}{
 		"type":       "object",
-		"properties": make(map[string]interface{}),
+		"properties": map[string]interface{}{},
 	}
+
+	jsonSchema, ok := schema.(eru_models.JSONSchema)
+	if !ok {
+		return inputSchema
+	}
+
+	if jsonSchema.Type != "" {
+		inputSchema["type"] = jsonSchema.Type
+	}
+
+	if len(jsonSchema.Properties) > 0 {
+		properties := map[string]interface{}{}
+		for name, prop := range jsonSchema.Properties {
+			propMap := map[string]interface{}{
+				"type": prop.Type,
+			}
+			if prop.Description != "" {
+				propMap["description"] = prop.Description
+			}
+			if prop.Format != "" {
+				propMap["format"] = prop.Format
+			}
+			if len(prop.Enum) > 0 {
+				propMap["enum"] = prop.Enum
+			}
+			if prop.Items != nil {
+				propMap["items"] = s.convertSchemaToInputSchema(*prop.Items)
+			}
+			properties[name] = propMap
+		}
+		inputSchema["properties"] = properties
+	}
+
+	if len(jsonSchema.Required) > 0 {
+		inputSchema["required"] = jsonSchema.Required
+	}
+
 	return inputSchema
 }
 

--- a/eru-ai/module_server/routes.go
+++ b/eru-ai/module_server/routes.go
@@ -20,7 +20,13 @@ func AddModuleRoutes(serverRouter *mux.Router, sh *module_store.StoreHolder) {
 	// MCP server endpoints using eru-server infrastructure
 	mcpServer := NewEruAIMCPServer(sh)
 
-	// Production WebSocket MCP endpoint
+	// Streamable HTTP MCP endpoint (Claude Desktop compatible)
+	mcpHttpHandler := server.CreateMCPHttpHandler(mcpServer)
+	serverRouter.Methods(http.MethodPost).Path("/mcp").HandlerFunc(mcpHttpHandler)
+	serverRouter.Methods(http.MethodGet).Path("/mcp").HandlerFunc(mcpHttpHandler)
+	serverRouter.Methods(http.MethodDelete).Path("/mcp").HandlerFunc(mcpHttpHandler)
+
+	// WebSocket MCP endpoint
 	serverRouter.Methods(http.MethodGet).Path("/mcp/websocket").HandlerFunc(
 		server.CreateMCPWebSocketHandler(mcpServer),
 	)

--- a/eru-server/server/mcp.go
+++ b/eru-server/server/mcp.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"sync"
 
+	"github.com/google/uuid"
 	logs "github.com/eru-tech/eru/eru-logs/eru-logs"
 )
 
@@ -111,12 +114,13 @@ type MCPServer interface {
 type MCPMessageHandler struct {
 	server      MCPServer
 	initialized bool
+	sessionId   string
 }
 
-func NewMCPMessageHandler(server MCPServer) *MCPMessageHandler {
+func NewMCPMessageHandler(server MCPServer, sessionId string) *MCPMessageHandler {
 	return &MCPMessageHandler{
-		server:      server,
-		initialized: false,
+		server:    server,
+		sessionId: sessionId,
 	}
 }
 
@@ -156,7 +160,6 @@ func (h *MCPMessageHandler) handleInitialize(ctx context.Context, request MCPMes
 		return h.createErrorResponse(request.ID, -32603, "Initialize failed", err.Error())
 	}
 
-	// Mark as initialized
 	h.initialized = true
 
 	resultBytes, err := json.Marshal(result)
@@ -175,15 +178,9 @@ func (h *MCPMessageHandler) handleInitialize(ctx context.Context, request MCPMes
 
 func (h *MCPMessageHandler) handleInitialized(ctx context.Context, request MCPMessage) ([]byte, error) {
 	h.initialized = true
-	logs.WithContext(ctx).Info("MCP server initialized")
-	logs.WithContext(ctx).Info(fmt.Sprintf("request: %v", request))
-	response := MCPMessage{
-		JSONRPCVersion: "2.0",
-		ID:             request.ID,
-		Result:         json.RawMessage("{}"),
-	}
-
-	return json.Marshal(response)
+	logs.WithContext(ctx).Info("MCP client initialized notification received")
+	// initialized is a client notification — no id, no response required
+	return nil, nil
 }
 
 func (h *MCPMessageHandler) handleListTools(ctx context.Context, request MCPMessage) ([]byte, error) {
@@ -222,8 +219,7 @@ func (h *MCPMessageHandler) handleCallTool(ctx context.Context, request MCPMessa
 	}
 
 	logs.WithContext(ctx).Info(fmt.Sprintf("Calling tool: %s", params.Name))
-	conversationId := "" //TODO: get conversationId from mcp client request
-	result, err := h.server.CallTool(ctx, conversationId, params)
+	result, err := h.server.CallTool(ctx, h.sessionId, params)
 	if err != nil {
 		logs.WithContext(ctx).Error(fmt.Sprintf("Tool execution error: %v", err))
 		return h.createErrorResponse(request.ID, -32603, fmt.Sprintf("Tool execution failed: %v", err), nil)
@@ -256,6 +252,110 @@ func (h *MCPMessageHandler) createErrorResponse(id interface{}, code int, messag
 	return json.Marshal(response)
 }
 
+// MCPSessionManager manages per-session MCPMessageHandler instances for HTTP transport.
+type MCPSessionManager struct {
+	mu       sync.RWMutex
+	sessions map[string]*MCPMessageHandler
+	server   MCPServer
+}
+
+func NewMCPSessionManager(server MCPServer) *MCPSessionManager {
+	return &MCPSessionManager{
+		sessions: make(map[string]*MCPMessageHandler),
+		server:   server,
+	}
+}
+
+func (m *MCPSessionManager) GetOrCreate(sessionId string) *MCPMessageHandler {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if h, ok := m.sessions[sessionId]; ok {
+		return h
+	}
+	h := NewMCPMessageHandler(m.server, sessionId)
+	m.sessions[sessionId] = h
+	return h
+}
+
+func (m *MCPSessionManager) Delete(sessionId string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.sessions, sessionId)
+}
+
+// CreateMCPHttpHandler creates an HTTP handler for the MCP Streamable HTTP transport.
+// Claude Desktop connects to this via POST /mcp (JSON-RPC) and GET /mcp (SSE for server notifications).
+func CreateMCPHttpHandler(server MCPServer) http.HandlerFunc {
+	manager := NewMCPSessionManager(server)
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		sessionId := r.Header.Get("Mcp-Session-Id")
+
+		switch r.Method {
+		case http.MethodPost:
+			if sessionId == "" {
+				sessionId = uuid.New().String()
+			}
+
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, "Bad request", http.StatusBadRequest)
+				return
+			}
+
+			handler := manager.GetOrCreate(sessionId)
+			response, err := handler.HandleMessage(ctx, body)
+			if err != nil {
+				logs.WithContext(ctx).Error("MCP HTTP handler error: " + err.Error())
+				http.Error(w, "Internal error", http.StatusInternalServerError)
+				return
+			}
+
+			w.Header().Set("Mcp-Session-Id", sessionId)
+
+			if response == nil {
+				// Notification accepted — no body
+				w.WriteHeader(http.StatusAccepted)
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write(response)
+
+		case http.MethodGet:
+			// SSE stream for server-to-client notifications
+			if sessionId == "" {
+				sessionId = uuid.New().String()
+			}
+			manager.GetOrCreate(sessionId)
+
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("Connection", "keep-alive")
+			w.Header().Set("Mcp-Session-Id", sessionId)
+			w.WriteHeader(http.StatusOK)
+
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+
+			// Hold open until client disconnects
+			<-ctx.Done()
+
+		case http.MethodDelete:
+			if sessionId != "" {
+				manager.Delete(sessionId)
+			}
+			w.WriteHeader(http.StatusNoContent)
+
+		default:
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
+	}
+}
+
 func CreateMCPWebSocketHandler(server MCPServer, config ...WebSocketConfig) http.HandlerFunc {
 	var wsConfig WebSocketConfig
 	if len(config) > 0 {
@@ -268,10 +368,9 @@ func CreateMCPWebSocketHandler(server MCPServer, config ...WebSocketConfig) http
 		wsConfig.Subprotocols = []string{"mcp"}
 	}
 
-	// Return a handler that creates a new message handler per connection
 	return func(w http.ResponseWriter, r *http.Request) {
-		// Create a new message handler for this connection
-		messageHandler := NewMCPMessageHandler(server)
+		sessionId := uuid.New().String()
+		messageHandler := NewMCPMessageHandler(server, sessionId)
 		wsHandler := NewWebSocketHandler(messageHandler.HandleMessage, wsConfig)
 		wsHandler.ServeHTTP(w, r)
 	}


### PR DESCRIPTION
## Summary
This PR adds support for the MCP Streamable HTTP transport protocol alongside the existing WebSocket implementation, enabling Claude Desktop compatibility. It introduces session management for HTTP connections and improves tool name parsing and schema conversion.

## Key Changes

### MCP Server Transport
- **Added HTTP Streamable transport handler** (`CreateMCPHttpHandler`) supporting:
  - POST requests for JSON-RPC messages
  - GET requests for Server-Sent Events (SSE) notifications
  - DELETE requests for session cleanup
  - Automatic session ID generation via UUID
  - Session ID propagation via `Mcp-Session-Id` header

- **Introduced `MCPSessionManager`** for managing per-session handler instances:
  - Thread-safe session storage with RWMutex
  - GetOrCreate pattern for session lifecycle management
  - Session deletion support

### Message Handler Updates
- Modified `MCPMessageHandler` to accept and store `sessionId` parameter
- Updated `NewMCPMessageHandler` constructor to require sessionId
- Fixed `handleInitialized` to properly handle client notifications (no response required)
- Replaced TODO placeholder with actual sessionId usage in `handleCallTool`
- Updated WebSocket handler to generate sessionId per connection

### Tool Name Parsing
- Changed tool name separator from underscore (`_`) to double underscore (`__`) for clarity
- Simplified `parseToolName` to use `strings.Split` instead of manual character iteration
- Updated tool name formatting in `ListTools` to use the new separator
- Added documentation for tool name format conventions

### Schema Conversion
- Enhanced `convertSchemaToInputSchema` to properly handle `eru_models.JSONSchema` objects
- Added support for schema properties including type, description, format, enum, and items
- Added required fields support
- Improved null safety with empty slice initialization

### Code Cleanup
- Removed unused global tools factory integration from `ListTools`
- Removed commented-out capabilities (Resources, Prompts, Logging)
- Removed unnecessary comments and improved code clarity
- Fixed nil slice handling in `ListTools` result

### Routes
- Added HTTP MCP endpoints (POST, GET, DELETE) at `/mcp` path
- Maintained existing WebSocket endpoint at `/mcp/websocket`

## Implementation Details
- HTTP transport uses standard HTTP status codes: 200 (OK), 202 (Accepted), 204 (No Content)
- SSE stream holds connection open until client disconnect via context cancellation
- Session IDs are generated using `github.com/google/uuid` for uniqueness
- Tool naming convention now clearly separates components: `project__tenant__toolname` or `project__tenant__agent__agentname`

https://claude.ai/code/session_01GkLCq43K87nskfeHb3Eq2z