### PR TITLE
fix(mcp): return 200 with {} body for notification responses

### DIFF
--- a/eru-server/server/mcp.go
+++ b/eru-server/server/mcp.go
@@ -313,15 +313,15 @@ func CreateMCPHttpHandler(server MCPServer) http.HandlerFunc {
 			}
 
 			w.Header().Set("Mcp-Session-Id", sessionId)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
 
 			if response == nil {
-				// Notification accepted — no body
-				w.WriteHeader(http.StatusAccepted)
+				// Notification — no JSON-RPC response body required, return empty object
+				w.Write([]byte("{}"))
 				return
 			}
 
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
 			w.Write(response)
 
 		case http.MethodGet:


### PR DESCRIPTION
Claude Desktop crashes with TypeError when it receives HTTP 202 with empty body for MCP notifications like initialized. Return 200 with {} instead.

https://claude.ai/code/session_01GkLCq43K87nskfeHb3Eq2z